### PR TITLE
Add dependencies and add option to search for MRs in specific group

### DIFF
--- a/MMM-Gitlab-MergeRequests.js
+++ b/MMM-Gitlab-MergeRequests.js
@@ -37,6 +37,7 @@ Module.register("MMM-Gitlab-MergeRequests",{
         environmnet: "",
         deployedBefore: "",
         deployedAfter: "",
+        gitlabGroup: ""
     },
     
     // Define required scripts.

--- a/MergeRequestFetcher.js
+++ b/MergeRequestFetcher.js
@@ -68,7 +68,14 @@ const MergeRequestFetcher = function (config) {
 	const getMergeRequestUrl = function(config) {
         let url = config.gitlabUrl;
         if(!url.endsWith('/') && !url.endsWith('\\')){
-            url = url + "/api/v4/merge_requests?";
+            url += "/api/v4";
+            
+            // append "groups/{gitlab group config}" if the gitlab group variable is set
+            // to use the group specific merge requests api
+            // docs: https://docs.gitlab.com/ee/api/merge_requests.html#list-group-merge-requests
+            if (!!config.gitlabGroup) url += "groups/" + config.gitlabGroup
+
+            url += "/merge_requests?";
         }
         url = url + "page=1&per_page="+(config.maxEntries*2);
         url = url + "&state="+config.state;

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ this to return the items you care about.
 | `tableClass`     | Name of the classes issued from `main.css`. <br><br>**Possible values:** xsmall, small, medium, large, xlarge. <br> **Default value:** _small._
 | `reloadInterval` | How often does the content needs to be fetched? (Seconds) <br><br> **Possible values:** `1` - `86400` <br> **Default value:** `300` (5 minutes)
 | `maxEntries`     | The maximum number of events shown. <br><br> **Possible values:** `0` - `100` <br> **Default value:** `10`
+| `gitlabGroup`    | The ID of your group that you want to get the merge requests from <br> **Default Value:** `""`
 | `maxTitleLength` | The maximum title length. <br><br> **Possible values:** `10` - `50` <br> **Default value:** `25`
 | `wrapEvents`     | Wrap event titles to multiple lines. Breaks lines at the length defined by `maxTitleLength`. <br><br> **Possible values:** `true` or `false` <br> **Default value:** `false`
 | `fade`           | Fade the future events to black. (Gradient) <br><br> **Possible values:** `true` or `false` <br> **Default value:** `true` |

--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ this to return the items you care about.
    ```
    cd <Your MagicMirror Directory>/modules
    git clone https://github.com/jkschoen/MMM-Gitlab-MergeRequests.git
+   cd MMM-Gitlab-MergeRequests
+   npm ci # install dependencies with pinned versions
    ```
 3. Edit the `config/config.js` file to add our module, and edit the configuration 
    to your liking. Below is an example configuration to give you an idea.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,14 @@
+{
+    "name": "MMM-Gitlab-MergeRequests",
+    "version": "1.0.0",
+    "lockfileVersion": 3,
+    "requires": true,
+    "packages": {
+        "": {
+            "name": "MMM-Gitlab-MergeRequests",
+            "version": "1.0.0",
+            "license": "MIT",
+            "devDependencies": {}
+        }
+    }
+}

--- a/package.json
+++ b/package.json
@@ -8,5 +8,7 @@
     "devDependencies": {
     },
     "dependencies": {
+      "request": "^2.88.2",
+      "valid-url": "^1.0.9"
     }
   }


### PR DESCRIPTION
The repo was missing dependencies for `valid-url` and `request` which I added using `npm install --save valid-url request`

I additionally added the option to specify a group ID so that the [group specific MR API](https://docs.gitlab.com/ee/api/merge_requests.html#list-group-merge-requests) is used (so you don't get random MRs when using the official gitlab.com instance)

If there is anything you don't quite understand let me know :)

